### PR TITLE
Reformat timestamps in factorio log

### DIFF
--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/mroote/factorio-server-manager/bootstrap"
-	"github.com/mroote/factorio-server-manager/factorio"
 	"io"
 	"io/ioutil"
 	"log"
@@ -15,6 +13,9 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/mroote/factorio-server-manager/bootstrap"
+	"github.com/mroote/factorio-server-manager/factorio"
 
 	"github.com/gorilla/mux"
 )
@@ -216,7 +217,7 @@ func LogTail(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
 	config := bootstrap.GetConfig()
-	resp, err = factorio.TailLog()
+	resp, err = factorio.TailLog(config.FactorioLog)
 	if err != nil {
 		resp = fmt.Sprintf("Could not tail %s: %s", config.FactorioLog, err)
 		return

--- a/src/factorio/gamelog.go
+++ b/src/factorio/gamelog.go
@@ -1,12 +1,17 @@
 package factorio
 
 import (
+	"errors"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/hpcloud/tail"
 	"github.com/mroote/factorio-server-manager/bootstrap"
-	"log"
 )
 
-func TailLog() ([]string, error) {
+func tailLog(filename string) ([]string, error) {
 	result := []string{}
 
 	config := bootstrap.GetConfig()
@@ -21,5 +26,54 @@ func TailLog() ([]string, error) {
 		result = append(result, line.Text)
 	}
 
+	result = reformatTimestamps(result)
+
 	return result, nil
+}
+
+func getOffset(line string) (string, error) {
+	re, _ := regexp.Compile(`^\d+.\d+`)
+
+	if !re.MatchString(line) {
+		log.Printf("This line has no offset", line)
+		return "error", errors.New(line)
+	}
+
+	offset := re.FindString(line)
+
+	return offset, nil
+}
+
+func getStartTime(line string) time.Time {
+	re, _ := regexp.Compile(`\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}`)
+	date := string(re.FindString(line))
+	startTime, _ := time.Parse(time.RFC3339, strings.Replace(date, " ", "T", 1)+"Z")
+
+	return startTime
+}
+
+func replaceTimestampInLine(line string, offset string, startTime time.Time) string {
+	offset, err := getOffset(line)
+	offsetDuration, _ := time.ParseDuration(offset + "s")
+	timestamp := startTime.Add(offsetDuration)
+
+	if err == nil {
+		return timestamp.Format("2006-01-02 15:04:05") + ":" + strings.Replace(line, offset, "", 1)
+	} else {
+		return line
+	}
+}
+
+func reformatTimestamps(log []string) []string {
+	firstLine := log[0]
+	startTime := getStartTime(firstLine)
+	result := []string{}
+
+	for i := range log {
+		line := strings.TrimLeft(log[i], " \t")
+		offset, _ := getOffset(line)
+		result = append(result, replaceTimestampInLine(line, offset, startTime))
+	}
+
+	return result
 }

--- a/src/factorio/gamelog.go
+++ b/src/factorio/gamelog.go
@@ -11,8 +11,9 @@ import (
 	"github.com/mroote/factorio-server-manager/bootstrap"
 )
 
-func tailLog(filename string) ([]string, error) {
-	result := []string{}
+func TailLog(filename string) ([]string, error) {
+	// Tail the Factorio game log file
+	var result []string
 
 	config := bootstrap.GetConfig()
 
@@ -46,7 +47,7 @@ func getOffset(line string) (string, error) {
 
 func getStartTime(line string) time.Time {
 	re, _ := regexp.Compile(`\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}`)
-	date := string(re.FindString(line))
+	date := re.FindString(line)
 	startTime, _ := time.Parse(time.RFC3339, strings.Replace(date, " ", "T", 1)+"Z")
 
 	return startTime
@@ -67,10 +68,10 @@ func replaceTimestampInLine(line string, offset string, startTime time.Time) str
 func reformatTimestamps(log []string) []string {
 	firstLine := log[0]
 	startTime := getStartTime(firstLine)
-	result := []string{}
+	var result []string
 
-	for i := range log {
-		line := strings.TrimLeft(log[i], " \t")
+	for _, line := range log {
+		line = strings.TrimLeft(line, " \t")
 		offset, _ := getOffset(line)
 		result = append(result, replaceTimestampInLine(line, offset, startTime))
 	}

--- a/src/factorio/gamelog.go
+++ b/src/factorio/gamelog.go
@@ -11,8 +11,8 @@ import (
 	"github.com/mroote/factorio-server-manager/bootstrap"
 )
 
+// TailLog tails the Factorio game log file
 func TailLog(filename string) ([]string, error) {
-	// Tail the Factorio game log file
 	var result []string
 
 	config := bootstrap.GetConfig()
@@ -36,7 +36,7 @@ func getOffset(line string) (string, error) {
 	re, _ := regexp.Compile(`^\d+.\d+`)
 
 	if !re.MatchString(line) {
-		log.Printf("This line has no offset", line)
+		log.Printf("This line has no offset %v\n", line)
 		return "error", errors.New(line)
 	}
 
@@ -60,9 +60,9 @@ func replaceTimestampInLine(line string, offset string, startTime time.Time) str
 
 	if err == nil {
 		return timestamp.Format("2006-01-02 15:04:05") + ":" + strings.Replace(line, offset, "", 1)
-	} else {
-		return line
 	}
+
+	return line
 }
 
 func reformatTimestamps(log []string) []string {


### PR DESCRIPTION
While using your very useful server manager, it always bothered me that you can't see the real date/time in the log file. 

Today I realized, that this has nothing to do with your software but with the format factorio stores the logs in. So I made this PR to reformat the log.

Maybe we could also implement a switch to toggle this feature. But as this would be part of the frontend and I do not know a lot about react, I will leave it as is.

This is my first code in go, so I am very open for suggestions depending code quality and style. Of course any other suggestions are welcome as well.

Hope to see this in upstream soon.