### PR TITLE
Handle absolute paths in settings/binary, configurable BaseMod dir

### DIFF
--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/mroote/factorio-server-manager/bootstrap"
-	"github.com/mroote/factorio-server-manager/factorio"
 	"io"
 	"io/ioutil"
 	"log"
@@ -15,6 +13,9 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/mroote/factorio-server-manager/bootstrap"
+	"github.com/mroote/factorio-server-manager/factorio"
 
 	"github.com/gorilla/mux"
 )
@@ -628,7 +629,7 @@ func UpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	config := bootstrap.GetConfig()
-	err = ioutil.WriteFile(filepath.Join(config.FactorioConfigDir, config.SettingsFile), settings, 0644)
+	err = ioutil.WriteFile(config.SettingsFile, settings, 0644)
 	if err != nil {
 		resp = fmt.Sprintf("Failed to save server settings: %v\n", err)
 		log.Println(resp)

--- a/src/bootstrap/config.go
+++ b/src/bootstrap/config.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/jessevdk/go-flags"
@@ -94,7 +93,7 @@ func (config *Config) loadServerConfig() {
 	err = decoder.Decode(&config)
 	failOnError(err, "Error decoding JSON config file.")
 
-	if !strings.HasPrefix(config.SettingsFile, "/") {
+	if !filepath.IsAbs(config.SettingsFile) {
 		config.SettingsFile = filepath.Join(config.FactorioConfigDir, config.SettingsFile)
 	}
 
@@ -134,7 +133,7 @@ func mapFlags(flags Flags) Config {
 		MaxUploadSize:           flags.FactorioMaxUpload,
 	}
 
-	if strings.HasPrefix(flags.FactorioBinary, "/") {
+	if filepath.IsAbs(flags.FactorioBinary) {
 		config.FactorioBinary = flags.FactorioBinary
 	} else {
 		config.FactorioBinary = filepath.Join(flags.FactorioDir, flags.FactorioBinary)

--- a/src/bootstrap/config.go
+++ b/src/bootstrap/config.go
@@ -3,13 +3,15 @@ package bootstrap
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jessevdk/go-flags"
 	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type Flags struct {
@@ -31,6 +33,7 @@ type Flags struct {
 type Config struct {
 	FactorioDir             string `json:"factorio_dir"`
 	FactorioSavesDir        string `json:"saves_dir"`
+	FactorioBaseModDir      string `json:"basemod_dir"`
 	FactorioModsDir         string `json:"mods_dir"`
 	FactorioModPackDir      string `json:"mod_pack_dir"`
 	FactorioConfigFile      string `json:"config_file"`
@@ -91,6 +94,14 @@ func (config *Config) loadServerConfig() {
 	err = decoder.Decode(&config)
 	failOnError(err, "Error decoding JSON config file.")
 
+	if !strings.HasPrefix(config.SettingsFile, "/") {
+		config.SettingsFile = filepath.Join(config.FactorioConfigDir, config.SettingsFile)
+	}
+
+	if config.FactorioBaseModDir == "" {
+		config.FactorioBaseModDir = filepath.Join(config.FactorioDir, "data", "base")
+	}
+
 	config.FactorioRconPort = randomPort()
 }
 
@@ -118,10 +129,15 @@ func mapFlags(flags Flags) Config {
 		FactorioModPackDir:      flags.ModPackDir,
 		FactorioConfigDir:       filepath.Join(flags.FactorioDir, "config"),
 		FactorioConfigFile:      filepath.Join(flags.FactorioDir, flags.FactorioConfigFile),
-		FactorioBinary:          filepath.Join(flags.FactorioDir, flags.FactorioBinary),
 		FactorioCredentialsFile: "./factorio.auth",
 		FactorioAdminFile:       "server-adminlist.json",
 		MaxUploadSize:           flags.FactorioMaxUpload,
+	}
+
+	if strings.HasPrefix(flags.FactorioBinary, "/") {
+		config.FactorioBinary = flags.FactorioBinary
+	} else {
+		config.FactorioBinary = filepath.Join(flags.FactorioDir, flags.FactorioBinary)
 	}
 
 	if runtime.GOOS == "windows" {

--- a/src/factorio/server.go
+++ b/src/factorio/server.go
@@ -3,8 +3,6 @@ package factorio
 import (
 	"bufio"
 	"encoding/json"
-	"github.com/mroote/factorio-server-manager/api/websocket"
-	"github.com/mroote/factorio-server-manager/bootstrap"
 	"io"
 	"io/ioutil"
 	"log"
@@ -15,6 +13,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/mroote/factorio-server-manager/api/websocket"
+	"github.com/mroote/factorio-server-manager/bootstrap"
 
 	"github.com/majormjr/rcon"
 )
@@ -85,7 +86,7 @@ func NewFactorioServer() (err error) {
 		return
 	}
 
-	settingsPath := filepath.Join(config.FactorioConfigDir, config.SettingsFile)
+	settingsPath := config.SettingsFile
 	var settings *os.File
 
 	if _, err = os.Stat(settingsPath); os.IsNotExist(err) {
@@ -165,7 +166,7 @@ func NewFactorioServer() (err error) {
 	}
 
 	//Load baseMod version
-	baseModInfoFile := filepath.Join(config.FactorioDir, "data", "base", "info.json")
+	baseModInfoFile := filepath.Join(config.FactorioBaseModDir, "info.json")
 	bmifBa, err := ioutil.ReadFile(baseModInfoFile)
 	if err != nil {
 		log.Printf("couldn't open baseMods info.json: %s", err)
@@ -226,7 +227,7 @@ func (server *Server) Run() error {
 	if err != nil {
 		log.Println("Failed to marshal FactorioServerSettings: ", err)
 	} else {
-		ioutil.WriteFile(filepath.Join(config.FactorioConfigDir, config.SettingsFile), data, 0644)
+		ioutil.WriteFile(config.SettingsFile, data, 0644)
 	}
 
 	args := []string{}
@@ -241,7 +242,7 @@ func (server *Server) Run() error {
 	args = append(args,
 		"--bind", server.BindIP,
 		"--port", strconv.Itoa(server.Port),
-		"--server-settings", filepath.Join(config.FactorioConfigDir, config.SettingsFile),
+		"--server-settings", config.SettingsFile,
 		"--rcon-port", strconv.Itoa(config.FactorioRconPort),
 		"--rcon-password", config.FactorioRconPass)
 

--- a/src/main.go
+++ b/src/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"github.com/mroote/factorio-server-manager/api"
-	"github.com/mroote/factorio-server-manager/bootstrap"
-	"github.com/mroote/factorio-server-manager/factorio"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/mroote/factorio-server-manager/api"
+	"github.com/mroote/factorio-server-manager/bootstrap"
+	"github.com/mroote/factorio-server-manager/factorio"
 )
 
 func main() {
@@ -19,7 +20,7 @@ func main() {
 	// Initialize Factorio Server struct
 	err := factorio.NewFactorioServer()
 	if err != nil {
-		log.Printf("Error occurred during Server initializaion: %v\n", err)
+		log.Printf("Error occurred during Server initialization: %v\n", err)
 		return
 	}
 


### PR DESCRIPTION
Hey all!

Love this project, I've only used it for a short time but already can't imagine not having it.  This PR is centered around some non-intuitive install configurations I've run in to using the AUR package for factorio on Arch Linux.  In short, the baseMod lives in `/usr/share`, the executable in `/usr/bin`, and the server settings in `/etc/factorio`, with most everything else falling into `/var/lib/factorio/.factorio`.  I've been able to get it working by symlinking everything to a single directory, but that felt messy and hacky so I modified the config logic to handle absolute paths and allow explicit base mod directory to be specified.  I have not, however, extended this behavior to other settings/paths- so I'm not sure this is the best way forward.

Ultimately, I'd just be happy enabling FSM to operate alongside this edge case install, only needing to change the config and flags.