### PR TITLE
Fix Dockerfile-build for Windows cross compilation

### DIFF
--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -1,14 +1,14 @@
 FROM alpine:latest as build
 
-RUN apk add --no-cache git make musl-dev go nodejs npm zip
+RUN apk add --no-cache git make musl-dev go nodejs npm zip mingw-w64-gcc
 
-ENV FACTORIO_BRANCH=develop
 ENV GOROOT /usr/lib/go
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
 ENV FACTORIO_ROOT /go/src/factorio-server-manager
 
-COPY build-release.sh /usr/local/bin/build-release.sh
+COPY docker/build-release.sh /usr/local/bin/build-release.sh
+COPY ./ $FACTORIO_ROOT
 
 RUN mkdir -p ${GOPATH}/bin
 RUN chmod u+x /usr/local/bin/build-release.sh
@@ -16,6 +16,7 @@ RUN chmod u+x /usr/local/bin/build-release.sh
 WORKDIR $FACTORIO_ROOT
 
 VOLUME /build
+VOLUME $FACTORIO_ROOT
 
 RUN ["/usr/local/bin/build-release.sh"]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -88,7 +88,7 @@ To create the bundle build the Dockerfile-build file with the following command.
 
 Run this command from the root factorio-server-manager directory.
 ```
-DOCKER_BUILDKIT=1 docker build --no-cache -f Dockerfile-build -t ofsm-build --target=output -o dist .
+DOCKER_BUILDKIT=1 docker build --no-cache -f docker/Dockerfile-build -t ofsm-build --target=output -o dist .
 ```
 
 ## For everyone who actually read this thing to the end

--- a/docker/README.md
+++ b/docker/README.md
@@ -82,13 +82,13 @@ Authentication is supported in the application, but it is recommended to ensure 
 For development purposes it also has the ability to create the docker image from local sourcecode. This is done by running `build.sh` in the `docker` directory. This will delete all old executables and the node_modules directory (runs `make build`). The created docker image will have the tag `factorio-server-manager:dev`.
 
 ### Creating release bundles
-A Dockerfile-build file is included for creating the release bundles.
+A Dockerfile-build file is included for creating the release bundles. Use Docker version 20 in order to use the BUILDKIT environment, some issues have been encountered with Docker version 19.
 
 To create the bundle build the Dockerfile-build file with the following command. The release bundles are output to the ./dist directory.
 
 Run this command from the root factorio-server-manager directory.
 ```
-DOCKER_BUILDKIT=1 docker build --no-cache -f docker/Dockerfile-build -t ofsm-build --target=output -o dist .
+DOCKER_BUILDKIT=1 docker build --no-cache -f docker/Dockerfile-build -t ofsm-build --target=build -o dist .
 ```
 
 ## For everyone who actually read this thing to the end

--- a/docker/README.md
+++ b/docker/README.md
@@ -85,6 +85,8 @@ For development purposes it also has the ability to create the docker image from
 A Dockerfile-build file is included for creating the release bundles.
 
 To create the bundle build the Dockerfile-build file with the following command. The release bundles are output to the ./dist directory.
+
+Run this command from the root factorio-server-manager directory.
 ```
 DOCKER_BUILDKIT=1 docker build --no-cache -f Dockerfile-build -t ofsm-build --target=output -o dist .
 ```

--- a/docker/build-release.sh
+++ b/docker/build-release.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-echo "Cloning ${FACTORIO_BRANCH}"
-git clone -b ${FACTORIO_BRANCH} https://github.com/mroote/factorio-server-manager.git ${FACTORIO_ROOT}
+go_version=$(go version)
+
+echo "Go Version: ${go_version}"
 echo "Creating build..."
 make gen_release
 echo "Copying build artifacts from ${PWD}"


### PR DESCRIPTION
Add packages for Windows compilation, add note to run from root directory to make build files.