### PR TITLE
run github actions only once on PR

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rlespinasse/github-slug-action@v3.x
-      - run: echo ${{ GITHUB_REPOSITORY_OWNER_PART }}
+      - run: echo $GITHUB_REPOSITORY_OWNER_PART
       - name: Cancel this build
         uses: andymckay/cancel-action@0.2
         if: github.event_name == 'pull_request' && env.GITHUB_REPOSITORY_OWNER_PART != "OpenFactorioServerManager"

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rlespinasse/github-slug-action@v3.x
-      - run: echo ${{ github.context }}
+      - run: echo "${{ github.context.ref }} -- ${{ github.context.sha }}"
       - name: Cancel this build
         uses: knoxfighter/cancel-action@master
         with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -15,7 +15,16 @@ env:
   dir: '../'
   conf: '../../conf.json.example'
 jobs:
+  check-double-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rlespinasse/github-slug-action@v3.x
+      - run: echo ${{ GITHUB_REPOSITORY_OWNER_PART }}
+      - name: Cancel this build
+        uses: andymckay/cancel-action@0.2
+        if: github.event_name == 'pull_request' && env.GITHUB_REPOSITORY_OWNER_PART != "OpenFactorioServerManager"
   test-npm:
+    needs: [ check-double-run ]
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -25,6 +34,7 @@ jobs:
       - uses: actions/setup-node@v1
       - run: make app/bundle
   test-go:
+    needs: [check-double-run]
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: rlespinasse/github-slug-action@v3.x
       - run: echo $GITHUB_REPOSITORY_OWNER_PART
       - name: Cancel this build
-        uses: andymckay/cancel-action@0.2
+        uses: knoxfighter/cancel-action@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'pull_request' && env.GITHUB_REPOSITORY_OWNER_PART == 'OpenFactorioServerManager'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -22,7 +22,7 @@ jobs:
       - run: echo $GITHUB_REPOSITORY_OWNER_PART
       - name: Cancel this build
         uses: andymckay/cancel-action@0.2
-        if: github.event_name == 'pull_request' && env.GITHUB_REPOSITORY_OWNER_PART != "OpenFactorioServerManager"
+        if: github.event_name == 'pull_request' && env.GITHUB_REPOSITORY_OWNER_PART != 'OpenFactorioServerManager'
   test-npm:
     needs: [ check-double-run ]
     strategy:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -22,6 +22,8 @@ jobs:
       - run: echo $GITHUB_REPOSITORY_OWNER_PART
       - name: Cancel this build
         uses: andymckay/cancel-action@0.2
+        with:
+          token: ${{ github.token }}
         if: github.event_name == 'pull_request' && env.GITHUB_REPOSITORY_OWNER_PART == 'OpenFactorioServerManager'
   test-npm:
     needs: [ check-double-run ]

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -4,7 +4,7 @@ on:
       - '**'
     tags-ignore:
       - '*.*'
-  pull_request:
+  pull_request_target:
     branches:
       - '**'
 env:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rlespinasse/github-slug-action@v3.x
-      - run: echo ${{ github.repository }}
+      - run: echo ${{ github.context }}
       - name: Cancel this build
         uses: knoxfighter/cancel-action@master
         with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rlespinasse/github-slug-action@v3.x
-      - run: echo $GITHUB_REPOSITORY_OWNER_PART
+      - run: echo $GITHUB_BASE_REF
       - name: Cancel this build
         uses: knoxfighter/cancel-action@master
         with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -19,12 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rlespinasse/github-slug-action@v3.x
-      - run: echo "${{ github.ref }} -- ${{ github.sha }}"
       - name: Cancel this build
-        uses: knoxfighter/cancel-action@master
+        uses: knoxfighter/cancel-multi-action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'pull_request' && env.GITHUB_REPOSITORY_OWNER_PART == 'OpenFactorioServerManager'
+        if: github.event_name == 'pull_request'
   test-npm:
     needs: [ check-double-run ]
     strategy:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Cancel this build
         uses: andymckay/cancel-action@0.2
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'pull_request' && env.GITHUB_REPOSITORY_OWNER_PART == 'OpenFactorioServerManager'
   test-npm:
     needs: [ check-double-run ]

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -22,7 +22,7 @@ jobs:
       - run: echo $GITHUB_REPOSITORY_OWNER_PART
       - name: Cancel this build
         uses: andymckay/cancel-action@0.2
-        if: github.event_name == 'pull_request' && env.GITHUB_REPOSITORY_OWNER_PART != 'OpenFactorioServerManager'
+        if: github.event_name == 'pull_request' && env.GITHUB_REPOSITORY_OWNER_PART == 'OpenFactorioServerManager'
   test-npm:
     needs: [ check-double-run ]
     strategy:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -4,7 +4,7 @@ on:
       - '**'
     tags-ignore:
       - '*.*'
-  pull_request_target:
+  pull_request:
     branches:
       - '**'
 env:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rlespinasse/github-slug-action@v3.x
-      - run: echo $GITHUB_BASE_REF
+      - run: echo ${{ github.repository }}
       - name: Cancel this build
         uses: knoxfighter/cancel-action@master
         with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rlespinasse/github-slug-action@v3.x
-      - run: echo "${{ github.context.ref }} -- ${{ github.context.sha }}"
+      - run: echo "${{ github.ref }} -- ${{ github.sha }}"
       - name: Cancel this build
         uses: knoxfighter/cancel-action@master
         with:


### PR DESCRIPTION
Prevent running the github actions twice, when we create a PR from a branch on this repo.