### PR TITLE
dont build static on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ factorio-server-manager-linux:
 	@echo "Building Backend - Linux"
 	@mkdir -p factorio-server-manager
 	@cd src; \
-	CGO_ENABLED=1 GO111MODULE=on GOOS=linux GOARCH=amd64 go build -ldflags="-extldflags=-static" -o ../factorio-server-manager/factorio-server-manager .
+	CGO_ENABLED=1 GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o ../factorio-server-manager/factorio-server-manager .
 
 factorio-server-manager-windows:
 	@echo "Building Backend - Windows"


### PR DESCRIPTION
I removed the static linking in the makefile. The build created with `make build` works on my Ubuntu 20.10 VM and on my Ubuntu 18.04 setup.
For some reason the executable created with GoLand is still not usable on 20.10, but that is problem :)

Please also run the script and test the executables on different systems. The docker image built works on my Ubuntu 18.04 system. It can be loaded as `ofsm/ofsm:fix-glibc`.