### PR TITLE
use ubuntu base image instead of alpine

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Glibc is required for Factorio Server binaries to run
-FROM frolvlad/alpine-glibc
+FROM ubuntu
 
 ENV FACTORIO_VERSION=stable \
     MANAGER_VERSION=0.10.0 \
@@ -9,7 +9,7 @@ VOLUME /opt/fsm-data /opt/factorio/saves /opt/factorio/mods /opt/factorio/config
 
 EXPOSE 80/tcp 34197/udp
 
-RUN apk add --no-cache curl tar xz unzip jq
+RUN apt-get update && apt-get install -y curl tar xz unzip jq && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
 

--- a/docker/Dockerfile-local
+++ b/docker/Dockerfile-local
@@ -1,5 +1,5 @@
 # Glibc is required for Factorio Server binaries to run
-FROM frolvlad/alpine-glibc
+FROM ubuntu
 
 ENV FACTORIO_VERSION=latest \
     RCON_PASS=""
@@ -8,7 +8,7 @@ VOLUME /opt/fsm-data /opt/factorio/saves /opt/factorio/mods /opt/factorio/config
 
 EXPOSE 80/tcp 34197/udp
 
-RUN apk add --no-cache curl tar xz unzip jq
+RUN apt-get update && apt-get install -y curl tar xz-utils unzip jq && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
 

--- a/src/factorio/saves.go
+++ b/src/factorio/saves.go
@@ -76,6 +76,7 @@ func CreateSave(filePath string) (string, error) {
 	cmdOutput, err := exec.Command(config.FactorioBinary, args...).Output()
 	if err != nil {
 		log.Printf("Error in creating Factorio save: %s", err)
+		log.Println(string(cmdOutput))
 		return "", err
 	}
 


### PR DESCRIPTION
This fixes problems running factorio, when the server-manager is dynamically linked to glibc.