### PR TITLE
Open conf.json in RDONLY when we only need to read it

### DIFF
--- a/src/bootstrap/config.go
+++ b/src/bootstrap/config.go
@@ -156,7 +156,7 @@ func (config *Config) loadServerConfig() {
 	// load and potentially update conf.json
 	config.updateConfigFile()
 
-	file, err := os.OpenFile(config.ConfFile, os.O_RDWR, 0)
+	file, err := os.OpenFile(config.ConfFile, os.O_RDONLY, 0)
 	failOnError(err, "Error loading config file.")
 	defer file.Close()
 


### PR DESCRIPTION
With this change, if conf.json contains all required fields (e.g. doesn't need writing to to set the rcon password etc) then factorio-server-manager will launch even if conf.json is read-only.

Without this change, it fails to start, with:

```
panic: Error loading config file.: open /opt/factorio-server-manager/conf.json: permission denied
```