### PR TITLE
Make admin file location configurable

### DIFF
--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -771,7 +771,7 @@ func UpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		err = ioutil.WriteFile(filepath.Join(config.FactorioConfigDir, config.FactorioAdminFile), admins, 0664)
+		err = ioutil.WriteFile(config.FactorioAdminFile, admins, 0664)
 		if err != nil {
 			resp = fmt.Sprintf("Failed to save admins: %s", err)
 			log.Println(resp)

--- a/src/bootstrap/config.go
+++ b/src/bootstrap/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	FactorioRconPass        string `json:"rcon_pass,omitempty"`
 	FactorioCredentialsFile string `json:"factorio_credentials_file,omitempty"`
 	FactorioIP              string `json:"factorio_ip,omitempty"`
-	FactorioAdminFile       string `json:"-"`
+	FactorioAdminFile       string `json:"factorio_admin_file,omitempty"`
 	ServerIP                string `json:"server_ip,omitempty"`
 	ServerPort              string `json:"server_port,omitempty"`
 	MaxUploadSize           int64  `json:"max_upload_size,omitempty"`
@@ -170,6 +170,10 @@ func (config *Config) loadServerConfig() {
 
 	if config.FactorioBaseModDir == "" {
 		config.FactorioBaseModDir = filepath.Join(config.FactorioDir, "data", "base")
+	}
+
+	if !filepath.IsAbs(config.FactorioAdminFile) {
+		config.FactorioAdminFile = filepath.Join(config.FactorioConfigDir, config.FactorioAdminFile)
 	}
 
 	// Set random port as rconPort

--- a/src/factorio/server.go
+++ b/src/factorio/server.go
@@ -183,13 +183,13 @@ func NewFactorioServer() (err error) {
 
 	// load admins from additional file
 	if (server.Version.Greater(Version{0, 17, 0})) {
-		if _, err = os.Stat(filepath.Join(config.FactorioConfigDir, config.FactorioAdminFile)); os.IsNotExist(err) {
+		if _, err = os.Stat(config.FactorioAdminFile); os.IsNotExist(err) {
 			//save empty admins-file
-			err = ioutil.WriteFile(filepath.Join(config.FactorioConfigDir, config.FactorioAdminFile), []byte("[]"), 0664)
+			err = ioutil.WriteFile(config.FactorioAdminFile, []byte("[]"), 0664)
 			server.Settings["admins"] = make([]string, 0)
 		} else {
 			var data []byte
-			data, err = ioutil.ReadFile(filepath.Join(config.FactorioConfigDir, config.FactorioAdminFile))
+			data, err = ioutil.ReadFile(config.FactorioAdminFile)
 			if err != nil {
 				log.Printf("Error loading FactorioAdminFile: %s", err)
 				return
@@ -256,7 +256,7 @@ func (server *Server) Run() error {
 		"--rcon-password", config.FactorioRconPass)
 
 	if (server.Version.Greater(Version{0, 17, 0})) {
-		args = append(args, "--server-adminlist", filepath.Join(config.FactorioConfigDir, config.FactorioAdminFile))
+		args = append(args, "--server-adminlist", config.FactorioAdminFile)
 	}
 
 	if server.Savefile == "Load Latest" {


### PR DESCRIPTION
This patch makes it possible to configure where the `server-adminlist.json` is located, which is useful if it's not in your Factorio configuration dir.

I also made it possible to specify a non-relative path to it, similar to some of the other options . This is helpful for me because all my writeable data is in an entirely separate location.