### PR TITLE
Make server console log file path configurable

### DIFF
--- a/src/bootstrap/config.go
+++ b/src/bootstrap/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	GlibcLibLoc             string `json:"-"`
 	Autostart               string `json:"-"`
 	ConsoleCacheSize        int    `json:"console_cache_size,omitempty"` // the amount of cached lines, inside the factorio output cache
+	ConsoleLogFile          string `json:"console_log_file,omitempty"`
 	Secure                  bool   `json:"secure"` // set to `false` to use this tool without SSL/TLS (Default: `true`)
 }
 
@@ -202,6 +203,7 @@ func (config *Config) mapFlags(flags Flags) {
 	config.FactorioCredentialsFile = "./factorio.auth"
 	config.FactorioAdminFile = "server-adminlist.json"
 	config.MaxUploadSize = flags.FactorioMaxUpload
+	config.ConsoleLogFile = filepath.Join(flags.FactorioDir, "factorio-server-console.log")
 
 	if filepath.IsAbs(flags.FactorioBinary) {
 		config.FactorioBinary = flags.FactorioBinary

--- a/src/factorio/server.go
+++ b/src/factorio/server.go
@@ -359,10 +359,10 @@ func (server *Server) parseRunningCommand(std io.ReadCloser) (err error) {
 
 func (server *Server) writeLog(logline string) error {
 	config := bootstrap.GetConfig()
-	logfileName := filepath.Join(config.FactorioDir, "factorio-server-console.log")
+	logfileName := config.ConsoleLogFile
 	file, err := os.OpenFile(logfileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
-		log.Printf("Cannot open logfile for appending Factorio Server output: %s", err)
+		log.Printf("Cannot open logfile %s for appending Factorio Server output: %s", logfileName, err)
 		return err
 	}
 	defer file.Close()
@@ -370,7 +370,7 @@ func (server *Server) writeLog(logline string) error {
 	logline = logline + "\n"
 
 	if _, err = file.WriteString(logline); err != nil {
-		log.Printf("Error appending to factorio-server-console.log: %s", err)
+		log.Printf("Error appending to %s: %s", logfileName, err)
 		return err
 	}
 


### PR DESCRIPTION
This patch makes it possible to configure where the `factorio-server-console.log` file is located. Without this, I was getting a lot of write errors in the logs, because my Factorio directory is not writeable.