### PR TITLE
Rcon port config

### DIFF
--- a/src/bootstrap/config.go
+++ b/src/bootstrap/config.go
@@ -177,8 +177,11 @@ func (config *Config) loadServerConfig() {
 		config.FactorioAdminFile = filepath.Join(config.FactorioConfigDir, config.FactorioAdminFile)
 	}
 
-	// Set random port as rconPort
-	config.FactorioRconPort = randomPort()
+	if config.FactorioRconPort == 0 {
+		config.FactorioRconPort = randomPort()
+		log.Println("Rcon port is empty, generated new one:")
+		log.Printf("Port number: %v", config.FactorioRconPort)
+	}
 }
 
 // Returns random port to use for rcon connection


### PR DESCRIPTION
Rcon port taken from config file or generated if empty

Mentioned in issue [240](https://github.com/OpenFactorioServerManager/factorio-server-manager/issues/240)