### PR TITLE
Update handlers.go

### DIFF
--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -133,10 +133,11 @@ func UploadSave(w http.ResponseWriter, r *http.Request) {
 
 	for _, saveFile := range r.MultipartForm.File["savefile"] {
 		ext := filepath.Ext(saveFile.Filename)
-		if ext != "zip" {
+		if ext != ".zip" {
 			// Only zip-files allowed
 			resp = fmt.Sprintf("Fileformat {%s} is not allowed", ext)
 			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return
 		}
 
 		file, err := saveFile.Open()


### PR DESCRIPTION
First of all the extension must be checked including the dot.
If not a zip file is uploaded, the process should be canceled immediately.

This will fix #250