### PR TITLE
Truncate config files when resaving.

### DIFF
--- a/src/bootstrap/config.go
+++ b/src/bootstrap/config.go
@@ -4,14 +4,15 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/securecookie"
-	"github.com/jessevdk/go-flags"
 	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
 	"time"
+
+	"github.com/gorilla/securecookie"
+	"github.com/jessevdk/go-flags"
 )
 
 type Flags struct {
@@ -59,7 +60,7 @@ type Config struct {
 	GlibcLibLoc             string `json:"-"`
 	Autostart               string `json:"-"`
 	ConsoleCacheSize        int    `json:"console_cache_size,omitempty"` // the amount of cached lines, inside the factorio output cache
-	Secure                  bool   `json:"secure"` // set to `false` to use this tool without SSL/TLS (Default: `true`)
+	Secure                  bool   `json:"secure"`                       // set to `false` to use this tool without SSL/TLS (Default: `true`)
 }
 
 // set Configs default values. JSON unmarshal will replace when it found something different
@@ -88,7 +89,7 @@ func GetConfig() Config {
 }
 
 func (config *Config) updateConfigFile() {
-	file, err := os.OpenFile(config.ConfFile, os.O_RDONLY, 0)
+	file, err := os.Open(config.ConfFile)
 	failOnError(err, "Error opening file")
 	defer file.Close()
 
@@ -138,7 +139,7 @@ func (config *Config) updateConfigFile() {
 
 	if resave {
 		// save json file again
-		file, err = os.OpenFile(config.ConfFile, os.O_WRONLY, 0)
+		file, err = os.Create(config.ConfFile)
 		failOnError(err, "Error opening file for writing")
 		defer file.Close()
 
@@ -156,7 +157,7 @@ func (config *Config) loadServerConfig() {
 	// load and potentially update conf.json
 	config.updateConfigFile()
 
-	file, err := os.OpenFile(config.ConfFile, os.O_RDWR, 0)
+	file, err := os.Open(config.ConfFile)
 	failOnError(err, "Error loading config file.")
 	defer file.Close()
 


### PR DESCRIPTION
Before this change config files would have remnants of the previous file's data. Now when saving, truncate the file before rewriting the JSON data. ~~This may possibly fix #294 as well.~~