### PR TITLE
Change Default Game Version

### DIFF
--- a/docker/Dockerfile-local
+++ b/docker/Dockerfile-local
@@ -1,7 +1,7 @@
 # Glibc is required for Factorio Server binaries to run
 FROM ubuntu
 
-ENV FACTORIO_VERSION=latest \
+ENV FACTORIO_VERSION=stable \
     RCON_PASS=""
 
 VOLUME /opt/fsm-data /opt/factorio/saves /opt/factorio/mods /opt/factorio/config

--- a/docker/docker-compose.simple.yaml
+++ b/docker/docker-compose.simple.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   factorio-server-manager:
-    image: "ofsm/ofsm:latest"
+    image: "ofsm/ofsm:stable"
     container_name: "factorio-server-manager"
     restart: "unless-stopped"
     environment:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     container_name: "factorio-server-manager"
     restart: "unless-stopped"
     environment:
-      - "FACTORIO_VERSION=latest"
+      - "FACTORIO_VERSION=stable"
       - "RCON_PASS"
     volumes:
       - "./fsm-data:/opt/fsm-data"


### PR DESCRIPTION
The default game version in docker image is "latest" instead of "stable". This means sometimes the container will pull beta version of the factorio server. 