### PR TITLE
Corrected xz package in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ VOLUME /opt/fsm-data /opt/factorio/saves /opt/factorio/mods /opt/factorio/config
 
 EXPOSE 80/tcp 34197/udp
 
-RUN apt-get update && apt-get install -y curl tar xz unzip jq && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl tar xz-utils unzip jq && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
 


### PR DESCRIPTION
It should be `xz-utils` instead of `xz` (was already correct in `Dckerfile-local`)