### PR TITLE
Added option to select a file for chat-logs

### DIFF
--- a/src/bootstrap/config.go
+++ b/src/bootstrap/config.go
@@ -62,7 +62,8 @@ type Config struct {
 	Autostart               string `json:"-"`
 	ConsoleCacheSize        int    `json:"console_cache_size,omitempty"` // the amount of cached lines, inside the factorio output cache
 	ConsoleLogFile          string `json:"console_log_file,omitempty"`
-	Secure                  bool   `json:"secure"` // set to `false` to use this tool without SSL/TLS (Default: `true`)
+	ChatLogFile             string `json:"chat_log_file,omitempty"` // separate log file for chat (incl join/quit)
+	Secure                  bool   `json:"secure"`                  // set to `false` to use this tool without SSL/TLS (Default: `true`)
 }
 
 // set Configs default values. JSON unmarshal will replace when it found something different

--- a/src/factorio/server.go
+++ b/src/factorio/server.go
@@ -273,6 +273,11 @@ func (server *Server) Run() error {
 		server.Cmd = exec.Command(config.FactorioBinary, args...)
 	}
 
+	// Write chat log to a different file if requested (if not it will be mixed-in with the default logfile)
+	if config.ChatLogFile != "" {
+		args = append(args, "--console-log", config.ChatLogFile)
+	}
+
 	server.StdOut, err = server.Cmd.StdoutPipe()
 	if err != nil {
 		log.Printf("Error opening stdout pipe: %s", err)


### PR DESCRIPTION
So it is more convenient to use with for example a Discord Chat bot. The other log file contains lots and lots of other stuff that I don't care about.

Closes https://github.com/OpenFactorioServerManager/factorio-server-manager/issues/306