### PR TITLE
Fixed custom chat log option

### DIFF
--- a/src/factorio/server.go
+++ b/src/factorio/server.go
@@ -264,6 +264,11 @@ func (server *Server) Run() error {
 	} else {
 		args = append(args, "--start-server", filepath.Join(config.FactorioSavesDir, server.Savefile))
 	}
+	
+	// Write chat log to a different file if requested (if not it will be mixed-in with the default logfile)
+	if config.ChatLogFile != "" {
+		args = append(args, "--console-log", config.ChatLogFile)
+	}
 
 	if config.GlibcCustom == "true" {
 		log.Println("Starting server with command: ", config.GlibcLocation, args)
@@ -272,12 +277,7 @@ func (server *Server) Run() error {
 		log.Println("Starting server with command: ", config.FactorioBinary, args)
 		server.Cmd = exec.Command(config.FactorioBinary, args...)
 	}
-
-	// Write chat log to a different file if requested (if not it will be mixed-in with the default logfile)
-	if config.ChatLogFile != "" {
-		args = append(args, "--console-log", config.ChatLogFile)
-	}
-
+	
 	server.StdOut, err = server.Cmd.StdoutPipe()
 	if err != nil {
 		log.Printf("Error opening stdout pipe: %s", err)


### PR DESCRIPTION
It seems that I tested it with an old (cached?) docker image. It was working for me but I updated some stuff and it was no longer working. It seems that the server was started before the `--console-log` option as added to the arguments. Sorry for that!