### PR TITLE
Display Save times in user locale and timezone

### DIFF
--- a/ui/App/views/Saves/Saves.jsx
+++ b/ui/App/views/Saves/Saves.jsx
@@ -71,7 +71,7 @@ const Saves = ({serverStatus}) => {
                             {saves.map(save =>
                                 <tr className="py-2 md:py-1" key={save.name}>
                                     <td className="pr-4">{save.name}</td>
-                                    <td className="pr-4">{(new Date(save.last_mod)).toISOString().replace('T', ' ').split('.')[0]}</td>
+                                    <td className="pr-4">{(new Date(save.last_mod)).toLocaleString()}</td>
                                     <td className="pr-4">{parseFloat(save.size / 1024 / 1024).toFixed(3)} MB</td>
                                     <td>
                                         { save.name !== 'Load Latest' && <>


### PR DESCRIPTION
This changes the displayed date-time format on the save page from ISO UTC to the user's locale and timezone as defined by their web browser. This should fix/close issue #299.