### PR TITLE
Add default port option for Factorio game server

### DIFF
--- a/conf.json.example
+++ b/conf.json.example
@@ -3,5 +3,7 @@
 	"sq_lite_database_file": "sqlite.db",
 	"cookie_encryption_key": "",
 	"settings_file": "server-settings.json",
-	"log_file": "factorio-server-manager.log"
+	"log_file": "factorio-server-manager.log",
+	"factorio_port": 34197,
+	"factorio_port_lock": false,
 }

--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -403,9 +403,13 @@ func KillServer(w http.ResponseWriter, r *http.Request) {
 }
 
 func CheckServer(w http.ResponseWriter, r *http.Request) {
+	var serverInfo = factorio.GetFactorioServer()
 	defer func() {
-		WriteResponse(w, factorio.GetFactorioServer())
+		WriteResponse(w, serverInfo)
 	}()
+
+	config := bootstrap.GetConfig()
+	serverInfo.DefaultPort = config.FactorioPort
 
 	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
 }

--- a/src/api/handlers.go
+++ b/src/api/handlers.go
@@ -410,6 +410,7 @@ func CheckServer(w http.ResponseWriter, r *http.Request) {
 
 	config := bootstrap.GetConfig()
 	serverInfo.DefaultPort = config.FactorioPort
+	serverInfo.PortLock = config.FactorioPortLock
 
 	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
 }

--- a/src/bootstrap/config.go
+++ b/src/bootstrap/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	FactorioCredentialsFile string `json:"factorio_credentials_file,omitempty"`
 	FactorioIP              string `json:"factorio_ip,omitempty"`
 	FactorioPort            string `json:"factorio_port,omitempty"`
+	FactorioPortLock        bool   `json:"factorio_port_lock,omitempty"`
 	FactorioAdminFile       string `json:"factorio_admin_file,omitempty"`
 	ServerIP                string `json:"server_ip,omitempty"`
 	ServerPort              string `json:"server_port,omitempty"`

--- a/src/bootstrap/config.go
+++ b/src/bootstrap/config.go
@@ -19,8 +19,9 @@ type Flags struct {
 	ConfFile           string `long:"conf" default:"./conf.json" description:"Specify location of Factorio Server Manager config file." env:"FSM_CONF"`
 	FactorioDir        string `long:"dir" default:"./" description:"Specify location of Factorio directory." env:"FSM_DIR"`
 	ServerIP           string `long:"host" default:"0.0.0.0" description:"Specify IP for webserver to listen on." env:"FSM_SERVER_IP"`
+	ServerPort         string `long:"port" default:"80" description:"Specify a port for the server." env:"FSM_PORT"`
 	FactorioIP         string `long:"game-bind-address" default:"0.0.0.0" description:"Specify IP for Factorio game server to listen on." env:"FSM_FACTORIO_IP"`
-	FactorioPort       string `long:"port" default:"80" description:"Specify a port for the server." env:"FSM_PORT"`
+	FactorioPort       string `long:"game-port" default:"34197" description:"Default port for the Factorio game server." env:"FSM_FACTORIO_PORT"`
 	FactorioConfigFile string `long:"config" default:"config/config.ini" description:"Specify location of Factorio config.ini file." env:"FSM_FACTORIO_CONFIG_FILE"`
 	FactorioMaxUpload  int64  `long:"max-upload" default:"20" description:"Maximum filesize for uploaded files in MB." env:"FSM_MAX_UPLOAD"`
 	FactorioBinary     string `long:"bin" default:"bin/x64/factorio" description:"Location of Factorio Server binary file." env:"FSM_BINARY"`
@@ -46,6 +47,7 @@ type Config struct {
 	FactorioRconPass        string `json:"rcon_pass,omitempty"`
 	FactorioCredentialsFile string `json:"factorio_credentials_file,omitempty"`
 	FactorioIP              string `json:"factorio_ip,omitempty"`
+	FactorioPort            string `json:"factorio_port,omitempty"`
 	FactorioAdminFile       string `json:"factorio_admin_file,omitempty"`
 	ServerIP                string `json:"server_ip,omitempty"`
 	ServerPort              string `json:"server_port,omitempty"`
@@ -212,8 +214,9 @@ func (config *Config) mapFlags(flags Flags) {
 	config.ConfFile = flags.ConfFile
 	config.FactorioDir = flags.FactorioDir
 	config.ServerIP = flags.ServerIP
-	config.ServerPort = flags.FactorioPort
+	config.ServerPort = flags.ServerPort
 	config.FactorioIP = flags.FactorioIP
+	config.FactorioPort = flags.FactorioPort
 	config.FactorioSavesDir = filepath.Join(flags.FactorioDir, "saves")
 	config.FactorioModsDir = filepath.Join(flags.FactorioDir, "mods")
 	config.FactorioModPackDir = flags.ModPackDir

--- a/src/factorio/server.go
+++ b/src/factorio/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	BindIP         string                 `json:"bindip"`
 	Port           int                    `json:"port"`
 	DefaultPort    string                 `json:"default_port"`
+	PortLock       bool                   `json:"port_lock"`
 	Running        bool                   `json:"running"`
 	Version        Version                `json:"fac_version"`
 	BaseModVersion string                 `json:"base_mod_version"`
@@ -250,9 +251,15 @@ func (server *Server) Run() error {
 		args = append(args, "--library-path", config.GlibcLibLoc, config.FactorioBinary, "--executable-path", config.FactorioBinary)
 	}
 
+	game_port := strconv.Itoa(server.Port)
+	if (config.FactorioPortLock) {
+		// Force the game to run with --game-port when "factorio_port_lock" is set to true in conf.json.
+		game_port = config.FactorioPort
+	}
+
 	args = append(args,
 		"--bind", server.BindIP,
-		"--port", strconv.Itoa(server.Port),
+		"--port", game_port,
 		"--server-settings", config.SettingsFile,
 		"--rcon-port", strconv.Itoa(config.FactorioRconPort),
 		"--rcon-password", config.FactorioRconPass)

--- a/src/factorio/server.go
+++ b/src/factorio/server.go
@@ -26,6 +26,7 @@ type Server struct {
 	Latency        int                    `json:"latency"`
 	BindIP         string                 `json:"bindip"`
 	Port           int                    `json:"port"`
+	DefaultPort    string                 `json:"default_port"`
 	Running        bool                   `json:"running"`
 	Version        Version                `json:"fac_version"`
 	BaseModVersion string                 `json:"base_mod_version"`
@@ -265,7 +266,7 @@ func (server *Server) Run() error {
 	} else {
 		args = append(args, "--start-server", filepath.Join(config.FactorioSavesDir, server.Savefile))
 	}
-	
+
 	// Write chat log to a different file if requested (if not it will be mixed-in with the default logfile)
 	if config.ChatLogFile != "" {
 		args = append(args, "--console-log", config.ChatLogFile)
@@ -278,7 +279,7 @@ func (server *Server) Run() error {
 		log.Println("Starting server with command: ", config.FactorioBinary, args)
 		server.Cmd = exec.Command(config.FactorioBinary, args...)
 	}
-	
+
 	server.StdOut, err = server.Cmd.StdoutPipe()
 	if err != nil {
 		log.Printf("Error opening stdout pipe: %s", err)

--- a/ui/App/components/Input.jsx
+++ b/ui/App/components/Input.jsx
@@ -9,6 +9,7 @@ const Input = ({
                    onKeyDown = () => null,
                    min = null,
                    value = undefined,
+                   readOnly = false,
                    disabled = false
                }) => {
     return (
@@ -22,6 +23,7 @@ const Input = ({
             defaultValue={defaultValue}
             min={min}
             value={value}
+            readonly={readOnly}
             disabled={disabled}
         />
     )

--- a/ui/App/views/Controls.jsx
+++ b/ui/App/views/Controls.jsx
@@ -89,7 +89,7 @@ const Controls = ({serverStatus}) => {
                                 <Input
                                     type="number"
                                     min={1}
-                                    defaultValue={"34197"}
+                                    defaultValue={serverStatus.default_port}
                                     register={register('port',{required: true})}
                                 />
                                 <Error error={errors.port} message="Port is required"/>

--- a/ui/App/views/Controls.jsx
+++ b/ui/App/views/Controls.jsx
@@ -90,6 +90,7 @@ const Controls = ({serverStatus}) => {
                                     type="number"
                                     min={1}
                                     defaultValue={serverStatus.default_port}
+                                    readOnly={serverStatus.port_freeze}
                                     register={register('port',{required: true})}
                                 />
                                 <Error error={errors.port} message="Port is required"/>


### PR DESCRIPTION
- Add a default Factorio port option that can be specified via command line flag --game-port
Or, via the the config json file with key "factorio_port". 

- Add a conf.json option "factorio_port_lock". When set to true, force
the game to run on the default "factorio_port" (--game-port on command
line flag). 

The default port will show up on the control page as the default
value for game server.

In cases where where we need a factorio server port different
from the default.

E.g. in my case, my admins can only use 34000 port since this is
the only port that's forwarded. This feature eliminates the
tedium & potential human error involved in having to maually
edit the game port number everytime.


