### PR TITLE
Docker: pass on parameters such as --autostart true to the fsm process

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -31,5 +31,5 @@ fi
 
 install_game
 
-cd /opt/fsm && ./factorio-server-manager --conf /opt/fsm-data/conf.json --dir /opt/factorio --port 80
+cd /opt/fsm && ./factorio-server-manager --conf /opt/fsm-data/conf.json --dir /opt/factorio --port 80 "$@"
 


### PR DESCRIPTION
## What's wrong?

While investigating #409 I found an issue with the docker packaging of fsm:

As it stands currently, all command line parameters meant for the fsm process passed when starting a container (with `docker run` or any other method) are ignored because `entrypoint.sh` does not actually pass them to the process. This is noticeable when trying to use `--autostart true` for example.

## The fix

The change to fix this is tiny: The parameters are forwarded to fsm by appending `"$@"` to the command that starts `factorio-server-manager`. 

When supplying parameters that are already included in the command (`--conf`, `--dir` and `--port`), the manually supplied parameters override the included ones, which seems like reasonable behaviour to me. If this is not desired, the `"$@"` can be moved to the left so the default arguments take precedence.

## Impact

This change does not affect the fsm code itself, but can help to mitigate various issues regarding autostart (see #409, #362, #301). The `Dockerfile` pulls the current release for packaging directly from the GitHub releases, so even if the current state of the development branch is not release-ready, this fix can quickly be distributed by updating the image on Docker Hub. Please consider doing so as soon as it's convenient. Thank you!